### PR TITLE
Add member page with placeholder for exec bios.

### DIFF
--- a/css/members.css
+++ b/css/members.css
@@ -1,0 +1,60 @@
+.member {
+	vertical-align: text-top;
+	display: inline-block;
+	position: relative;
+	margin-left: 40px;
+	margin-right: 40px;
+	height: 300px;
+	margin-top: 40px;
+}
+
+.member a {
+	text-decoration: none;
+	color: inherit;
+}
+
+.member p {
+	font-size: 24px;
+	margin: 5px auto;
+	position: relative;
+	text-align: center;
+}
+
+.member img {
+	height: 200px;
+	opacity: 0.6;
+    filter: alpha(opacity=60);
+	padding-bottom: 20;
+	transition: all .2s ease-in-out;
+	border-radius: 50%;
+}
+
+.member img:hover {
+	opacity: 1;
+    filter: alpha(opacity=100);
+}
+
+.exec_board_cont {
+	max-width: 1200px;
+	margin: 0 auto 40px auto;
+}
+
+#members {
+	width: 100%;
+	text-align: center;
+}
+
+a.btn {
+	padding:20px 30px;
+	width:300px;
+	height:100px;
+	text-decoration:none;
+	background-color:lightgrey;
+	font-size:24px;
+	color:black;
+	transition: all .2s ease-in-out;
+}
+
+a.btn:hover {
+	background-color:grey;
+}

--- a/css/members.css
+++ b/css/members.css
@@ -1,60 +1,30 @@
-.member {
+.roster {
 	vertical-align: text-top;
 	display: inline-block;
 	position: relative;
 	margin-left: 40px;
 	margin-right: 40px;
-	height: 300px;
-	margin-top: 40px;
+	margin-top: 0px;
 }
 
-.member a {
-	text-decoration: none;
-	color: inherit;
-}
-
-.member p {
-	font-size: 24px;
+.roster h1 {
+	font-size: 28px;
 	margin: 5px auto;
-	position: relative;
-	text-align: center;
+	text-align: center
 }
 
-.member img {
-	height: 200px;
-	opacity: 0.6;
-    filter: alpha(opacity=60);
-	padding-bottom: 20;
-	transition: all .2s ease-in-out;
-	border-radius: 50%;
+.roster p {
+	font-size: 16px;
+	margin: 5px auto;
+	text-align: center
 }
 
-.member img:hover {
-	opacity: 1;
-    filter: alpha(opacity=100);
-}
-
-.exec_board_cont {
-	max-width: 1200px;
+.subteam_list {
+	max-width: 800px;
 	margin: 0 auto 40px auto;
 }
 
 #members {
 	width: 100%;
 	text-align: center;
-}
-
-a.btn {
-	padding:20px 30px;
-	width:300px;
-	height:100px;
-	text-decoration:none;
-	background-color:lightgrey;
-	font-size:24px;
-	color:black;
-	transition: all .2s ease-in-out;
-}
-
-a.btn:hover {
-	background-color:grey;
 }

--- a/index.html
+++ b/index.html
@@ -37,6 +37,9 @@
 			circuit design, programming, and manufacturing.  Currently we attend
 			NASA's Robotic Mining Competition, an assortment of National Robotics
 			Challenges, and the Xtreme Collegiate Clash tournament.</p>
+			<p style="font-size:24px;max-width:1200px;margin:0 auto 70px auto;">
+			View our full team roster <a href="members.html#roster">here</a>.
+			</p>
 			<img style="width: 100vw;" src="res/fullteam.jpg"/>
 			<p class="hd">Executive Board</p>
 			<div class="division" style="margin-bottom:30px"></div>
@@ -90,6 +93,9 @@
 					<p>Faculty Advisor</p>
 					<p>Dr. Bachmann</p>
 				</div>
+				<p style="font-size:24px;max-width:1200px;margin:0 auto 70px auto;">
+				Learn more about our executive board <a href="members.html#exec">here</a>.
+				</p>
 			</div>
 		</div>
 

--- a/members.html
+++ b/members.html
@@ -140,6 +140,9 @@
 		<a class="anchor" id="exec"></a>
 		<p class="hd">Executive Board Biographies</p>
 		<div class="division"></div>
+		<p class="info">
+			Biographies from our executive board are forthcoming...
+		</p>
     </div>
 
 		<script src="js/footer.js"></script>

--- a/members.html
+++ b/members.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>CWRUbotix Members</title>
+		<meta charset="UTF-8">
+		<meta name="description" content="The home of Case Western Reserve University's undergraduate robotics club.">
+		<meta name="author" content="CWRUbotix">
+		<link href="css/site.css" rel="stylesheet">
+		<link href="css/members.css" rel="stylesheet" />
+		<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200' rel='stylesheet' type='text/css'>
+	</head>
+
+	<body>
+	<script src="js/navbar.js"></script>
+	<div class="topspace"></div>
+
+    <div id="members">
+		<a class="anchor" id="roster"></a>
+		<p class="hd">Our Members</p>
+		<div class="division"></div>
+		
+		<a class="anchor" id="exec"></a>
+		<p class="hd">Executive Board Biographies</p>
+		<div class="division"></div>
+    </div>
+
+		<script src="js/footer.js"></script>
+	</body>
+</html>

--- a/members.html
+++ b/members.html
@@ -16,7 +16,73 @@
 
     <div id="members">
 		<a class="anchor" id="roster"></a>
-		<p class="hd">Our Members</p>
+		<p class="hd">NASA RMC Members</p>
+		<div class="division"></div>
+		<div class="subteam_list">
+			<div class="roster">
+				<h1>Team Leads</h1>
+				<p>Steven Leonis</p>
+				<p>Ben Lindstrom</p>
+				<p>Karolyn Spencer</p>
+				<p>Anno van den Akker</p>
+			</div>
+			<div class="roster">
+				<h1>Excavation</h1>
+				<p>Serena Cai</p>
+				<p>Judy De Angelis</p>
+				<p>Clarissa Goldsmith</p>
+				<p>Noah Kaplan</p>
+				<p>Jack Kindle</p>
+				<p>Séamus Sullivan</p>
+				<p>Peter Welter</p>
+			</div>
+			<div class="roster">
+				<h1>Locomotion</h1>
+				<p>Jacob Bejune</p>
+				<p>Adam Cordingley</p>
+				<p>Sam Ehrenstein</p>
+				<p>Zac Ewaska</p>
+				<p>Rhys Hamlet</p>
+				<p>Jacob Lewton</p>
+				<p>Paul Nettleton</p>
+				<p>Ross O'Sullivan</p>
+				<p>Greg Yungen</p>
+			</div>
+			<div class="roster">
+				<h1>Deposition</h1>
+				<p>Jacob Porter</p>
+				<p>Lydia Sgouros</p>
+				<p>Robert Steward</p>
+				<p>Alexander Trimbach</p>
+				<p>Nathaniel Trujillo</p>
+				<p>George Vo</p>
+				<p>Jackson White</p>
+			</div>
+			<div class="roster">
+				<h1>Software</h1>
+				<p>Lucas Alva-Ganoza</p>
+				<p>Jared Cassarly</p>
+				<p>Robbie Dozier</p>
+				<p>Imran Hossain</p>
+				<p>Seohyun Jung</p>
+				<p>Andrea Norris</p>
+				<p>Dylan Plummer</p>
+				<p>Ashley Roberson</p>
+				<p>James Tang</p>
+				<p>Tyler Thieding</p>
+				<p>Chad-Andrew Wolfe</p>
+				<p>Steven Xie</p>
+			</div>
+			<div class="roster">
+				<h1>Hardware</h1>
+				<p>Darshan G. Parikh</p>
+				<p>Phong Nguyen</p>
+				<p>Paula Van Rooy</p>
+				<p>Malcolm Reitmeyer</p>
+			</div>
+		</div>
+		
+		<p class="hd">NRC Members</p>
 		<div class="division"></div>
 		
 		<a class="anchor" id="exec"></a>

--- a/members.html
+++ b/members.html
@@ -84,6 +84,58 @@
 		
 		<p class="hd">NRC Members</p>
 		<div class="division"></div>
+		<div class="subteam_list">
+			<div class="roster">
+				<h1>AVC</h1>
+				<p>Jiahe Chen</p>
+				<p>Yuqi Hu</p>
+				<p>Yimeng Liu</p>
+				<p>Jason Sun</p>
+			</div>
+			<div class="roster">
+				<h1>Maze</h1>
+				<p>Mark Goldberg</p>
+				<p>Kim Mackey</p>
+				<p>Tommy Moawad</p>
+				<p>Rory O'Neill</p>
+				<p>Jason Paximadas</p>
+				<p>Paul Schroeder</p>
+				<p>Alice Zhang</p>
+				<p>Kristien Zorob</p>
+			</div>
+			<div class="roster">
+				<h1>PlayBot</h1>
+				<p>Micensie Barrett</p>
+				<p>Emmett Donnelley-Power</p>
+				<p>Hannah Fox</p>
+				<p>Gabe Maguire</p>
+				<p>Matt Mitrovich</p>
+				<p>Riki Motoyma</p>
+				<p>Shota Nemoto</p>
+				<p>Andrew Tarnoff</p>
+			</div>
+			<div class="roster">
+				<h1>SumoBot</h1>
+				<p>Jared Cassarly</p>
+				<p>Jared Clark</p>
+				<p>Marcus Daly</p>
+				<p>Tommy Lu</p>
+				<p>Tiffany Nguyen</p>
+				<p>Rahul Pokharna</p>
+				<p>Sibi Sengottuvel</p>
+				<p>Marty Zhu</p>
+			</div>
+			<div class="roster">
+				<h1>T-1000</h1>
+				<p>Aman Gupta</p>
+				<p>Jessica Harding</p>
+				<p>Daniel Kessler</p>
+				<p>Adam Rice</p>
+				<p>Zane Varner</p>
+				<p>Joshua Volmer</p>
+				<p>Jenny Xu</p>
+			</div>
+		</div>
 		
 		<a class="anchor" id="exec"></a>
 		<p class="hd">Executive Board Biographies</p>


### PR DESCRIPTION
- Update "members" section of homepage to include a link to the roster section of a members page.
- Update "executive board" section of homepage to include a link to the executive board bios section of a members page.
- Populate a member roster using data from our team's Google Drive roster.
- **Note that there are no executive board biographies at the moment; there is only a placeholder for them once they are written.**